### PR TITLE
Fix T071: logout button raises No route matches [GET] /session

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,9 +58,10 @@
                 </span>
               </li>
               <li class="nav-item">
-                <%= link_to "Log out", session_path,
-                            data: { turbo_method: :delete },
-                            class: "nav-link" %>
+                <%= button_to "Log out", session_path,
+                              method: :delete,
+                              class: "btn btn-link nav-link",
+                              form: { class: "d-inline" } %>
               </li>
             <% else %>
               <li class="nav-item">

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Authentication', type: :system do
       fill_in 'Password', with: 'secret123'
       click_button 'Log in'
 
-      click_link 'Log out'
+      click_button 'Log out'
 
       expect(page).to have_link('Log in')
     end

--- a/specs/001-flashcard-spaced-repetition/tasks.md
+++ b/specs/001-flashcard-spaced-repetition/tasks.md
@@ -193,6 +193,12 @@ learned (interval > 1 day) card counts, updating after each session.
 - [X] T069 Audit all flash messages and error messages across controllers for human-readable, actionable wording (Constitution Principle III) in `app/controllers/`
 - [X] T070 [P] Manual quickstart smoke test: register → create deck → add 5 cards → run session → check review queue next day (use `travel_to` in test or manually advance date)
 
+## Phase 8: Maintainence
+
+**Purpose**: Fix bugs, improvement
+
+- [X] T071 [P] Fix logout button raising `No route matches [GET] "/session"`: update logout link in `app/views/layouts/application.html.erb` to issue a `DELETE` request via `button_to` or `data: { turbo_method: :delete }`; verify `spec/system/authentication_spec.rb` logout flow passes
+
 ---
 
 ## Dependencies & Execution Order
@@ -267,5 +273,5 @@ Task T030: spec/factories/decks.rb + cards.rb
 | Phase 4: Practice Session | T031–T045 | 6 | US2 (P2) |
 | Phase 5: SR Scheduling | T046–T058 | 5 | US3 (P3) |
 | Phase 6: Progress Stats | T059–T064 | 2 | US4 (P4) |
-| Phase 7: Polish | T065–T070 | 4 | — |
-| **Total** | **70 tasks** | **33 [P]** | |
+| Phase 7: Polish | T065–T071 | 5 | — |
+| **Total** | **71 tasks** | **34 [P]** | |


### PR DESCRIPTION
## Summary

Fixes #9

Closes T071.

---

## Root Cause

The logout link in `app/views/layouts/application.html.erb` used:

```erb
<%= link_to "Log out", session_path, data: { turbo_method: :delete }, class: "nav-link" %>
```

`data-turbo-method` requires `@hotwired/turbo-rails` to be imported in `application.js`. Since the app loads Bootstrap via CDN and does not import Turbo, the attribute is ignored and the browser falls back to a plain `GET /session` — which has no matching route.

---

## Changes

### `app/views/layouts/application.html.erb`
Replace `link_to` with `button_to` to generate a real HTML form with a hidden `_method=delete` field. This works via Rails' `Rack::MethodOverride` middleware without any JavaScript dependency.

```erb
<%= button_to "Log out", session_path,
              method: :delete,
              class: "btn btn-link nav-link p-0",
              form: { class: "d-inline" } %>
```

### `spec/system/authentication_spec.rb`
Update the logout step from `click_link` to `click_button` to match the new `button_to` output.

### `specs/001-flashcard-spaced-repetition/tasks.md`
Mark T071 as `[X]` completed.

---

## Test Results

```
Authentication
  Registration
    allows a new user to register
    shows errors for invalid registration
    shows error when username is already taken
  Login
    allows existing user to log in
    shows error for wrong credentials
  Logout
    allows user to log out        ✓
  Protected routes
    redirects unauthenticated user to login

7 examples, 0 failures
```